### PR TITLE
Features to connect between tester-host and vlan-tagged testee port.

### DIFF
--- a/app/flows/patch_to_vlan_host_broadcast_flow.rb
+++ b/app/flows/patch_to_vlan_host_broadcast_flow.rb
@@ -1,0 +1,17 @@
+class PatchToVlanHostBroadcastFlow < ActiveFlow::Base
+  def self.create(vlan_id:)
+    send_flow_mod_add(0xdad1c001,
+                      priority: 0x2,
+                      match: Match.new(in_port: 1,
+                                       destination_mac_address: 'ff:ff:ff:ff:ff:ff',
+                                       vlan_vid: vlan_id),
+                      actions: [StripVlanHeader.new, SendOutPort.new(:flood)])
+  end
+
+  def self.destroy(vlan_id)
+    send_flow_mod_delete(0xdad1c001,
+                         match: Match.new(in_port: 1,
+                                          destination_mac_address: 'ff:ff:ff:ff:ff:ff',
+                                          vlan_vid: vlan_id))
+  end
+end

--- a/app/flows/patch_to_vlan_host_flow.rb
+++ b/app/flows/patch_to_vlan_host_flow.rb
@@ -1,0 +1,17 @@
+class PatchToVlanHostFlow < ActiveFlow::Base
+  def self.create(destination_mac_address:, out_port:, vlan_id:)
+    send_flow_mod_add(0xdad1c001,
+                      match: Match.new(in_port: 1,
+                                       destination_mac_address: destination_mac_address,
+                                       vlan_vid: vlan_id),
+                      actions: [StripVlanHeader.new, SendOutPort.new(out_port)])
+  end
+
+  def self.destroy(destination_mac_address:, out_port:, vlan_id:)
+    send_flow_mod_delete(0xdad1c001,
+                         match: Match.new(in_port: 1,
+                                          destination_mac_address: destination_mac_address,
+                                          vlan_vid: vlan_id),
+                         out_port: out_port)
+  end
+end

--- a/app/flows/vlan_host_to_patch_flow.rb
+++ b/app/flows/vlan_host_to_patch_flow.rb
@@ -2,7 +2,12 @@ class VlanHostToPatchFlow < ActiveFlow::Base
   def self.create(in_port:, vlan_id:)
     send_flow_mod_add(0xdad1c001,
                       match: Match.new(in_port: in_port),
-                      actions: [SetVlanVid.new(vlan_id),
-                                SendOutPort.new(Vhost.all.size + 1)])
+                      actions: [SetVlanVid.new(vlan_id), SendOutPort.new(1)])
+  end
+
+  def self.destroy(in_port:, vlan_id:)
+    send_flow_mod_delete(0xdad1c001,
+                         match: Match.new(in_port: in_port),
+                         out_port: 1)
   end
 end

--- a/features/internal_tests/vlan_patch.feature
+++ b/features/internal_tests/vlan_patch.feature
@@ -1,27 +1,35 @@
-@wip
 Feature: パッチに VLAN タグを指定
   Background:
     Given PacketIn を調べる OpenFlow スイッチ
     And DPID が 0x123 の NetTester 物理スイッチ
-    And VLAN を有効にしたテストホスト 2 台を起動:
+    And VLAN を有効にしたテストホスト 3 台を起動:
       | Host | VLAN ID |
       |    1 |     100 |
       |    2 |     200 |
+      |    3 |     100 |
     And NetTester 物理スイッチとテスト対象のスイッチを次のように接続:
       | Physical Port | Testee Port |
       |             2 |           1 |
       |             3 |           2 |
-
+      |             4 |           3 |
   Scenario: 仮想ポートに VLAN ID を指定してパッチを作る
     When 次のパッチを追加:
       | Virtual Port | Physical Port |
       |            2 |             2 |
       |            3 |             3 |
+      |            4 |             4 |
     And 各テストホストから次のようにパケットを送信:
       | Source Host | Destination Host |
       |           1 |                2 |
-      |           2 |                1 |
+      |           2 |                3 |
+      |           3 |                1 |
+    Then 各テストホストは以下の数パケットを受信する:
+      | Source Host | Destination Host | Received Packets |
+      |           1 |                2 |                0 |
+      |           2 |                3 |                0 |
+      |           3 |                1 |                2 |
     Then テスト対象の OpenFlow スイッチの次のポートに PacketIn が届く:
       | Port | VLAN ID |
       |    1 |     100 |
       |    2 |     200 |
+      |    3 |     100 |

--- a/fixtures/packet_in_logger.rb
+++ b/fixtures/packet_in_logger.rb
@@ -2,13 +2,23 @@
 require 'English'
 
 class PacketInLogger < Trema::Controller
-  def packet_in(_dpid, message)
+  def start(_argv)
+    logger.info "#{name} started"
+  end
+
+  def switch_ready(dpid)
+    logger.info "Switch #{dpid.to_hex} connected"
+  end
+
+  def packet_in(dpid, message)
     # TODO: make message#vlan? work
-    if Pio::Parser::EthernetFrame.read(message.raw_data).ether_type.to_i == Pio::EthernetHeader::EtherType::VLAN
-      logger.info "PACKET_IN: Port = #{message.in_port}, VLAN ID = #{Pio::Parser.read(message.raw_data).vlan_vid_internal}"
+    if Pio::EthernetFrame.read(message.raw_data).ether_type.to_i == Pio::Ethernet::Type::VLAN
+      logger.info "PACKET_IN: Port = #{message.in_port}, VLAN ID = #{Pio::Parser.read(message.raw_data).vlan_vid}"
     else
       logger.info "PACKET_IN: Port = #{message.in_port}"
     end
+    # flooding without learning/flow-mod
+    send_packet_out(dpid, packet_in: message, actions: SendOutPort.new(:flood))
   rescue
     logger.error $ERROR_INFO.inspect
   end

--- a/lib/net_tester.rb
+++ b/lib/net_tester.rb
@@ -30,11 +30,13 @@ module NetTester
     controller_file = File.expand_path File.join(__dir__, 'net_tester/controller.rb')
     sh "bundle exec trema run #{controller_file} -L #{Phut.log_dir} -P #{Phut.pid_dir} -S #{Phut.socket_dir} --daemon -- #{physical_switch_dpid} #{vlan}"
     @test_switch = TestSwitch.create(dpid: 0xdad1c001)
-
     connect_device_to_virtual_port(device: network_device, port_number: 1)
   end
 
-  def self.connect_device_to_virtual_port(device:, port_number:)
+  def self.connect_device_to_virtual_port(device:, port_number:, host_name:'')
+    if host_name
+      controller.set_host_name_of_port_number(host_name, port_number)
+    end
     @test_switch.add_numbered_port port_number, device
   end
 
@@ -56,7 +58,9 @@ module NetTester
                          mac_address: mac_address[each - 1],
                          device: link.device(host_name),
                          arp_entries: arp_entries)
-      @test_switch.add_numbered_port each + 1, link.device(port_name)
+      connect_device_to_virtual_port(host_name: host_name,
+                                     device: link.device(port_name),
+                                     port_number: each + 1)
     end
   end
 

--- a/lib/net_tester/controller.rb
+++ b/lib/net_tester/controller.rb
@@ -13,10 +13,11 @@ class NetTesterController < Trema::Controller
   # args1: 'host_name0:vlan_id0,host_name1:vlan_id1,host_name2:vlan_id2,...'
   def start(args)
     @physical_switch_dpid = args.first.to_i
-    @vlan_id = (args[1] || '').split(',').each_with_object({}) do |each, hash|
-      raise "Invalid argument: #{args.inspect}" unless /host(\d+):(\d+)/=~ each
-      hash[Regexp.last_match(1).to_i] = Regexp.last_match(2).to_i
+    @vlan_id_of_host_name = (args[1] || '').split(',').each_with_object({}) do |each, hash|
+      raise "Invalid argument: #{args.inspect}" unless /([\w_]+):(\d+)/=~ each
+      hash[Regexp.last_match(1)] = Regexp.last_match(2).to_i
     end
+    @host_name_of_port_number = {}
     logger.info "#{name} started (Physical switch dpid = #{@physical_switch_dpid.to_hex})"
   end
 
@@ -26,7 +27,9 @@ class NetTesterController < Trema::Controller
     # TODO: maybe need more precise broadcasting control?
     return unless dpid != 0xdad1001
     send_flow_mod_add(0xdad1c001,
-                      match: Match.new(destination_mac_address: 'ff:ff:ff:ff:ff:ff'),
+                      priority: 0x1,
+                      match: Match.new(in_port: 1,
+                                       destination_mac_address: 'ff:ff:ff:ff:ff:ff'),
                       actions: SendOutPort.new(:flood))
   end
 
@@ -35,7 +38,7 @@ class NetTesterController < Trema::Controller
       raise "Physical switch #{@physical_switch_dpid.to_hex} is not yet connected to #{self.class}"
     end
     Patch.create(physical_switch_dpid: @physical_switch_dpid,
-                 vlan_id: @vlan_id[source_port],
+                 vlan_id: vlan_id_of_port_number(source_port),
                  source_port: source_port,
                  source_mac_address: source_mac_address,
                  destination_port: destination_port)
@@ -43,6 +46,7 @@ class NetTesterController < Trema::Controller
 
   def destroy_patch(source_port:, source_mac_address:, destination_port:)
     Patch.destroy(physical_switch_dpid: @physical_switch_dpid,
+                  vlan_id: vlan_id_of_port_number(source_port),
                   source_port: source_port,
                   source_mac_address: source_mac_address,
                   destination_port: destination_port)
@@ -50,5 +54,16 @@ class NetTesterController < Trema::Controller
 
   def list_patches
     Patch.all.map(&:to_s).join("\n")
+  end
+
+  def set_host_name_of_port_number(host_name, port_number)
+    @host_name_of_port_number[port_number] = host_name
+  end
+
+  private
+
+  def vlan_id_of_port_number(port_number)
+    # TODO: raise if not found port_nubmer:host_name:vlan_id combination
+    @vlan_id_of_host_name[@host_name_of_port_number[port_number]]
   end
 end

--- a/lib/net_tester/patch.rb
+++ b/lib/net_tester/patch.rb
@@ -5,10 +5,12 @@ module NetTester
                     vlan_id:, source_port:, source_mac_address:, destination_port:)
       if vlan_id
         VlanHostToPatchFlow.create(in_port: source_port, vlan_id: vlan_id)
+        PatchToVlanHostFlow.create(destination_mac_address: source_mac_address, out_port: source_port, vlan_id: vlan_id)
+        PatchToVlanHostBroadcastFlow.create(vlan_id: vlan_id)
       else
         HostToPatchFlow.create(in_port: source_port)
+        PatchToHostFlow.create(destination_mac_address: source_mac_address, out_port: source_port)
       end
-      PatchToHostFlow.create(destination_mac_address: source_mac_address, out_port: source_port)
       PatchToNetworkFlow.create(source_mac_address: source_mac_address, out_port: destination_port,
                                 physical_switch_dpid: physical_switch_dpid)
       NetworkToPatchFlow.create(in_port: destination_port,
@@ -16,7 +18,12 @@ module NetTester
     end
 
     def self.destroy(physical_switch_dpid:,
-                     source_port:, source_mac_address:, destination_port:)
+                     vlan_id:, source_port:, source_mac_address:, destination_port:)
+      if vlan_id
+        VlanHostToPatchFlow.destroy(in_port: source_port, vlan_id: vlan_id)
+        PatchToVlanHostFlow.destroy(out_port: source_port, vlan_id: vlan_id)
+        PatchToVlanHostBroadcastFlow.destroy(vlan_id: vlan_id)
+      end
       HostToPatchFlow.destroy(in_port: source_port)
       PatchToHostFlow.destroy(destination_mac_address: source_mac_address, out_port: source_port)
       PatchToNetworkFlow.destroy(source_mac_address: source_mac_address, out_port: destination_port,


### PR DESCRIPTION
* `app/flows/patch_to_vlan_host*.rb` を追加しました。
  各ファイルにあるクラスで Testee host と vlan-tagged testee port を接続する flow rule を生成します。
  あわせて `lib/net_tester/patch.rb` の flow rule 生成ロジックも修正しました。
* `NetTesterController#switch_ready` に no-vlan broadcast 制御用の default flow rule を追加しました。
* vlan-tagged port と host との接続テスト用に
  `features/internal_tests/vlan_patch.feature` が動作するように修正しました。
* `vlan_patch.feature` によるテストのために `PacketInlogger` controller による testee 動作を変更しました。
  このコントローラを使った testee は repeater-hub として振る舞います。
  (MAC learningなどをせずに常に入ってきたパケットをFloodingする。)
* `NetTester.#connect_device_to_virtual_port`に `host_name` argument を追加しました。
  tester host-name と接続先ポート番号を紐付けるために使います。
  * Vlan-tagged port への接続の時、NetTester controller に `vlan` option で host-name/vlan-id 情報を渡すのに加えて、patch 設定時(`#connect_device_to_virtual_port`）に host-name/port-number 情報を渡します。これをもとに内部で host/vlan/port 情報を組み合わせます。
