### PR TITLE
Build testee direct connection patch (port-to-port/p2p patch)

### DIFF
--- a/app/flows/host_to_patch_flow.rb
+++ b/app/flows/host_to_patch_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control flows from tester-host to patch(OVS).
 class HostToPatchFlow < ActiveFlow::Base
   def self.create(in_port:)
     send_flow_mod_add(0xdad1c001,

--- a/app/flows/network_to_network_patch_flow.rb
+++ b/app/flows/network_to_network_patch_flow.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Control flows between testee-devices via patch(physical-switch).
+class NetworkToNetworkPatchFlow < ActiveFlow::Base
+  def self.create(physical_switch_dpid:, source_port:, destination_port:)
+    send_flow_mod_add(physical_switch_dpid,
+                      match: Match.new(in_port: source_port),
+                      actions: SendOutPort.new(destination_port))
+  end
+
+  def self.destroy(physical_switch_dpid:, source_port:, destination_port:)
+    send_flow_mod_delete(physical_switch_dpid,
+                         match: Match.new(in_port: source_port),
+                         out_port: destination_port)
+  end
+end

--- a/app/flows/network_to_patch_flow.rb
+++ b/app/flows/network_to_patch_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control flows from testee-device to patch(physical-switch).
 class NetworkToPatchFlow < ActiveFlow::Base
   def self.create(physical_switch_dpid:, in_port:)
     send_flow_mod_add(physical_switch_dpid,

--- a/app/flows/patch_to_host_flow.rb
+++ b/app/flows/patch_to_host_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control flows from patch(OVS) to tester-host.
 class PatchToHostFlow < ActiveFlow::Base
   def self.create(destination_mac_address:, out_port:)
     send_flow_mod_add(0xdad1c001,

--- a/app/flows/patch_to_network_flow.rb
+++ b/app/flows/patch_to_network_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control flows from patch(physical-switch) to testee-device.
 class PatchToNetworkFlow < ActiveFlow::Base
   def self.create(physical_switch_dpid:, source_mac_address:, out_port:)
     send_flow_mod_add(physical_switch_dpid,

--- a/app/flows/patch_to_vlan_host_broadcast_flow.rb
+++ b/app/flows/patch_to_vlan_host_broadcast_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control vlan-tagged broadcast flow from patch(OVS) to tester-host.
 class PatchToVlanHostBroadcastFlow < ActiveFlow::Base
   def self.create(vlan_id:)
     send_flow_mod_add(0xdad1c001,

--- a/app/flows/patch_to_vlan_host_flow.rb
+++ b/app/flows/patch_to_vlan_host_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control vlan-tagged unicast flow from patch(OVS) to tester-host.
 class PatchToVlanHostFlow < ActiveFlow::Base
   def self.create(destination_mac_address:, out_port:, vlan_id:)
     send_flow_mod_add(0xdad1c001,

--- a/app/flows/vlan_host_to_patch_flow.rb
+++ b/app/flows/vlan_host_to_patch_flow.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Control vlan-tagged unicast flow from tester-host to patch(OVS).
 class VlanHostToPatchFlow < ActiveFlow::Base
   def self.create(in_port:, vlan_id:)
     send_flow_mod_add(0xdad1c001,
@@ -5,7 +8,7 @@ class VlanHostToPatchFlow < ActiveFlow::Base
                       actions: [SetVlanVid.new(vlan_id), SendOutPort.new(1)])
   end
 
-  def self.destroy(in_port:, vlan_id:)
+  def self.destroy(in_port:)
     send_flow_mod_delete(0xdad1c001,
                          match: Match.new(in_port: in_port),
                          out_port: 1)

--- a/bin/net_tester
+++ b/bin/net_tester
@@ -68,7 +68,7 @@ module NetTester
       end
     end
 
-    desc 'Add a patch'
+    desc 'Add a vport-to-port patch'
     command :add do |c|
       c.desc 'port number of virtual switch'
       c.flag [:vport]
@@ -94,6 +94,25 @@ module NetTester
         exit_now!("#{options[:port]}: invalid port") if options[:port].to_i < 1
 
         NetTester.add options[:vport].to_i, options[:port].to_i
+      end
+    end
+
+    desc 'Add a port-to-port direct patch'
+    command :add_p2p do |c|
+      c.desc 'a couple of port numbers of physical switch'
+      c.flag [:ports]
+      c.desc 'Location to find socket files'
+      c.flag [:S, :socket_dir], default_value: Trema::DEFAULT_SOCKET_DIR
+
+      c.action do |_global_options, options, _args|
+        Phut.socket_dir = options[:socket_dir]
+        exit_now!('NetTester is not running') unless NetTester.running?
+        raise '--ports option is mandatory' if options[:ports].nil?
+        ports = options[:ports].split(',').uniq
+        if ports.length != 2 || ports[0].to_i < 1 || ports[1].to_i < 1
+          exit_now!("#{options[:ports]}: invalid port pair")
+        end
+        NetTester.add_p2p ports[0].to_i, ports[1].to_i
       end
     end
 

--- a/features/commands/add_p2p.feature
+++ b/features/commands/add_p2p.feature
@@ -1,0 +1,57 @@
+Feature: net_tester add_p2p コマンド
+
+  NetTester ユーザは、"net_tester add_p2p --ports ポート番号,ポート番号" コマンドで
+  テスト対象のネットワーク機器間を直結できる。
+
+  実行例:
+  $ net_tester add_p2p --ports 3,5
+
+  Background:
+    Given テスト対象のイーサネットスイッチ
+    And DPID が 0x123 の NetTester 物理スイッチ
+    And NetTester を起動
+    And テストホスト 2 台
+    And NetTester 物理スイッチとテスト対象のスイッチを次のように接続:
+      | Physical Port | Testee Port |
+      |             2 |           2 |
+      |             3 |           3 |
+
+  Scenario: パッチが重複するとエラー
+    When コマンド `net_tester add_p2p --ports 2,3 -S sockets` の実行に成功
+    Then コマンド `net_tester add --port 2 --vport 2 -S sockets` を実行
+    And 終了ステータスは 0 ではない
+    And コマンドの出力は "Port 2 is already in use by other patch" を含む
+
+  Scenario: --ports を指定しないとエラー
+    When コマンド `net_tester add_p2p -S sockets` を実行
+    Then 終了ステータスは 0 ではない
+    And コマンドの出力は "--ports option is mandatory" を含む
+
+  Scenario: --ports で指定するポートの数が足りないとエラー
+    When コマンド `net_tester add_p2p --ports 2 -S sockets` を実行
+    Then 終了ステータスは 0 ではない
+    And コマンドの出力は "2: invalid port pair" を含む
+
+  Scenario: --ports で指定するポートの数が多いとエラー
+    When コマンド `net_tester add_p2p --ports 2,3,4 -S sockets` を実行
+    Then 終了ステータスは 0 ではない
+    And コマンドの出力は "2,3,4: invalid port pair" を含む
+
+  Scenario: --ports で指定するポート番号が同じだとエラー
+    When コマンド `net_tester add_p2p --ports 3,3 -S sockets` を実行
+    Then 終了ステータスは 0 ではない
+    And コマンドの出力は "3,3: invalid port pair" を含む
+
+  Scenario: --ports で指定するポートにマイナスのポート番号が含まれるとエラー
+    When コマンド `net_tester add_p2p --ports 2,-3 -S sockets` を実行
+    Then 終了ステータスは 0 ではない
+    And コマンドの出力は "2,-3: invalid port pair" を含む
+
+  Scenario: run せずに add_p2p するとエラー
+    Given コマンド `net_tester kill -S sockets` の実行に成功
+    When I run `net_tester add_p2p --ports 2,3 -S sockets`
+    Then the exit status should not be 0
+    Then the output should contain:
+      """
+      NetTester is not running
+      """

--- a/features/internal_tests/p2p_patch.feature
+++ b/features/internal_tests/p2p_patch.feature
@@ -1,0 +1,24 @@
+Feature: テスト対象ポート間パッチング
+  Background:
+    Given DPID が 0x123 の NetTester 物理スイッチ
+    And NetTester を起動
+    And NetTester 物理スイッチとテスト対象ホストを次のように接続:
+      | Physical Port | Host |
+      |             2 |    1 |
+      |             3 |    2 |
+      |             4 |    3 |
+
+  Scenario: NW機器間パッチを設定する
+    When 次のNW機器間パッチを追加:
+      | Physical Port A | Physical Port B |
+      |               3 |               4 |
+    And 各テストホストから次のようにパケットを送信:
+      | Source Host | Destination Host |
+      |           1 |                2 |
+      |           2 |                3 |
+      |           3 |                1 |
+    Then 各テストホストは以下の数パケットを受信する:
+      | Source Host | Destination Host | Received Packets |
+      |           1 |                2 |                0 |
+      |           2 |                3 |                1 |
+      |           3 |                1 |                0 |

--- a/features/step_definitions/p2p_patch_steps.rb
+++ b/features/step_definitions/p2p_patch_steps.rb
@@ -1,0 +1,39 @@
+# coding: utf-8
+# frozen_string_literal: true
+Given(/^NetTester 物理スイッチとテスト対象ホストを次のように接続:$/) do |table|
+  ip_of_host = {}
+  mac_of_host = {}
+  vhost_arp_list = []
+
+  table.hashes.each do |each|
+    host_id = each['Host']
+    ip_address = "192.168.0.#{host_id}"
+    ip_of_host[host_id] = ip_address
+    mac_address = "00:ba:dc:ab:1e:#{format('%02x', host_id)}"
+    mac_of_host[host_id] = mac_address
+    vhost_arp_list.append "#{ip_address}/#{mac_address}"
+  end
+
+  arp_entries = vhost_arp_list.join(',')
+  table.hashes.each do |each|
+    pport_id = each['Physical Port'].to_i
+    pport_name = "pport#{pport_id}"
+    host_id = each['Host']
+    host_name = "host#{host_id}"
+    link = Phut::Link.create(host_name, pport_name)
+    Phut::Vhost.create(name: host_name,
+                       ip_address: ip_of_host[host_id],
+                       mac_address: mac_of_host[host_id],
+                       device: link.device(host_name),
+                       arp_entries: arp_entries)
+    @physical_test_switch.add_numbered_port(pport_id, link.device(pport_name))
+  end
+end
+
+When(/^次のNW機器間パッチを追加:$/) do |table|
+  table.hashes.each do |each|
+    pport_a = each['Physical Port A'].to_i
+    pport_b = each['Physical Port B'].to_i
+    NetTester.add_p2p(pport_a, pport_b)
+  end
+end

--- a/lib/net_tester.rb
+++ b/lib/net_tester.rb
@@ -45,10 +45,8 @@ module NetTester
     connect_device_to_virtual_port(device: network_device, port_number: 1)
   end
 
-  def self.connect_device_to_virtual_port(device:, port_number:, host_name:'')
-    if host_name
-      controller.set_host_name_of_port_number(host_name, port_number)
-    end
+  def self.connect_device_to_virtual_port(device:, port_number:, host_name: '')
+    host_name && controller.set_host_name_of_port_number(host_name, port_number)
     @test_switch.add_numbered_port port_number, device
   end
 
@@ -66,10 +64,8 @@ module NetTester
       port_name = "port#{each + 1}"
       link = Phut::Link.create(host_name, port_name)
       Phut::Vhost.create(name: host_name,
-                         ip_address: ip_address[each - 1],
-                         mac_address: mac_address[each - 1],
-                         device: link.device(host_name),
-                         arp_entries: arp_entries)
+                         ip_address: ip_address[each - 1], mac_address: mac_address[each - 1],
+                         device: link.device(host_name), arp_entries: arp_entries)
       connect_device_to_virtual_port(host_name: host_name,
                                      device: link.device(port_name),
                                      port_number: each + 1)
@@ -83,6 +79,10 @@ module NetTester
     controller.create_patch(source_port: vport,
                             source_mac_address: mac_address,
                             destination_port: port)
+  end
+
+  def self.add_p2p(port_a, port_b)
+    controller.create_p2p_patch(source_port: port_a, destination_port: port_b)
   end
 
   def self.list

--- a/lib/net_tester/controller.rb
+++ b/lib/net_tester/controller.rb
@@ -44,6 +44,15 @@ class NetTesterController < Trema::Controller
                  destination_port: destination_port)
   end
 
+  def create_p2p_patch(source_port:, destination_port:)
+    unless @physical_switch_started
+      raise "Physical switch #{@physical_switch_dpid.to_hex} is not yet connected to #{self.class}"
+    end
+    Patch.create_p2p(physical_switch_dpid: @physical_switch_dpid,
+                     source_port: source_port,
+                     destination_port: destination_port)
+  end
+
   def destroy_patch(source_port:, source_mac_address:, destination_port:)
     Patch.destroy(physical_switch_dpid: @physical_switch_dpid,
                   vlan_id: vlan_id_of_port_number(source_port),


### PR DESCRIPTION
テスト対象NW機器のポート間を(物理OFS経由で)1対1に直結させる機能を追加しました。
* p2p patch 用のフロー生成機能を `app/flows/network_to_network_patch_flows.rb` に追加
  * あわせて `bin/net_tester` に `add_p2p` コマンドを追加。
  * `NetTester::.#add[_p2p]` をするときに、p2p patch で既に使われているポートが指定された場合は例外を発生させるようにしました。
  * net_tester コマンドのテスト(`features/commands/add_p2p.feature`)と p2p patch 動作テスト (`features/internal_tests/p2p_patch.feature`) を追加。
* いくつか rubocop check に引っかかったところを修正してあります。
