### PR TITLE
implement a work-around of tcp checksum error in vlan trunk

### DIFF
--- a/lib/net_tester/netns.rb
+++ b/lib/net_tester/netns.rb
@@ -43,6 +43,7 @@ module NetTester
                                         destination_port: @physical_port_number,
                                         vlan_id: @vlan_id)
       @netns.device = link.device(@netns.name)
+      @netns.exec("ethtool -K #{@netns.device} tx off")
     end
   end
 end


### PR DESCRIPTION
I discover tcp checksum is incorrect at using vlan trunk mode.
So, I propose this work-around, set all virtual link to no-tx-checksum-offload.